### PR TITLE
Fix issue of loading the Kotlin language file

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"grammars": [{
 			"language": "kotlin",
 			"scopeName": "source.Kotlin",
-			"path": "./syntaxes/kotlin.tmLanguage"
+			"path": "./syntaxes/Kotlin.tmLanguage"
 		}]
 	},
 	"devDependencies": {


### PR DESCRIPTION
The name of the grammar file declared in package.json had a case
mismatch causing the file not to be found upon the extension load.
This commit simply changes the case of the filename declared in
package.json to match the actual filename.