### PR TITLE
Add lateinit and dynamic keywords

### DIFF
--- a/syntaxes/Kotlin.tmLanguage
+++ b/syntaxes/Kotlin.tmLanguage
@@ -567,7 +567,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\b(const|typealias|var|val|public|private|protected|abstract|final|enum|open|attribute|annotation|override|inline|var|val|vararg|lazy|in|out|ref|internal|data)\b</string>
+					<string>\b(const|typealias|var|val|public|private|protected|abstract|final|enum|open|attribute|annotation|override|inline|var|val|vararg|lazy|in|out|ref|internal|data|lateinit|dynamic)\b</string>
 					<key>name</key>
 					<string>storage.modifier.kotlin</string>
 				</dict>


### PR DESCRIPTION
Adding  `lateinit` as a keyword to support late initialized properties.

```
lateinit var subject: TestSubject
```

I'm also adding `dynamic` to support dynamic typing for kotlinjs

```
external fun require(module: String): dynamic
```