### PR TITLE
Fix backticks in imports.

### DIFF
--- a/syntaxes/Kotlin.tmLanguage
+++ b/syntaxes/Kotlin.tmLanguage
@@ -549,14 +549,14 @@
 							<key>name</key>
 							<string>keyword.other.kotlin</string>
 						</dict>
-						<key>2</key>
+						<key>4</key>
 						<dict>
 							<key>name</key>
 							<string>keyword.other.kotlin</string>
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>^\s*(import)\s+[^ $]+\s+(as)?</string>
+					<string>^\s*(import)\s+[^ $.]+(\.([`][^$`]+[`]|[^` $.]+))+\s+(as)?</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
There was a problem with ticks in imports. See images below. Made the regex a bit more complex to handle ticks there ;)
Before:
![image](https://user-images.githubusercontent.com/5698911/35995404-7ebd2756-0d13-11e8-89d7-592b37eeec86.png)
After:
![image](https://user-images.githubusercontent.com/5698911/35995411-87c7d0bc-0d13-11e8-8d39-88fbad60ed21.png)
