### PR TITLE
add `lateinit` support

### DIFF
--- a/syntaxes/Kotlin.tmLanguage
+++ b/syntaxes/Kotlin.tmLanguage
@@ -471,7 +471,7 @@
           </dict>
           <dict>
             <key>match</key>
-            <string>\b(external|public|private|protected|internal|abstract|final|sealed|enum|open|annotation|override|vararg|typealias|expect|actual|suspend|yield)\b</string>
+            <string>\b(external|public|private|protected|internal|abstract|final|sealed|enum|open|annotation|override|vararg|typealias|expect|actual|suspend|yield|lateinit)\b</string>
             <key>name</key>
             <string>storage.modifier.kotlin</string>
           </dict>


### PR DESCRIPTION
adds `lateinit` keyword to the list of storage modifiers (storage.modifier.kotlin)

The lateinit keyword isn't currently being highlighted in vscode, because it's not in the grammar. This simply adds it to the possible matches for storage modifiers to have it properly highlighted