### PR TITLE
Fix #31 - Fix "Syntax highlighting breaks after < and <= operators"

### DIFF
--- a/syntaxes/Kotlin.tmLanguage
+++ b/syntaxes/Kotlin.tmLanguage
@@ -471,7 +471,7 @@
           </dict>
           <dict>
             <key>match</key>
-            <string>\b(external|public|private|protected|internal|abstract|final|sealed|enum|open|annotation|override|vararg|typealias|expect|actual|suspend|yield)\b</string>
+            <string>\b(external|public|private|protected|internal|abstract|final|sealed|enum|open|annotation|override|vararg|typealias|expect|actual|suspend|yield|out|in)\b</string>
             <key>name</key>
             <string>storage.modifier.kotlin</string>
           </dict>
@@ -825,43 +825,6 @@
             </dict>
             <key>name</key>
             <string>entity.name.type.class.kotlin</string>
-          </dict>
-          <dict>
-            <key>begin</key>
-            <string>\&lt;</string>
-            <key>beginCaptures</key>
-            <dict>
-              <key>0</key>
-              <dict>
-                <key>name</key>
-                <string>punctuation.definition.generic.begin.kotlin</string>
-              </dict>
-            </dict>
-            <key>end</key>
-            <string>\&gt;</string>
-            <key>endCaptures</key>
-            <dict>
-              <key>0</key>
-              <dict>
-                <key>name</key>
-                <string>punctuation.definition.generic.end.kotlin</string>
-              </dict>
-            </dict>
-            <key>name</key>
-            <string>meta.generic.kotlin</string>
-            <key>patterns</key>
-            <array>
-              <dict>
-                <key>match</key>
-                <string>\b(out|in)\b</string>
-                <key>name</key>
-                <string>storage.modifier.kotlin</string>
-              </dict>
-              <dict>
-                <key>include</key>
-                <string>#types</string>
-              </dict>
-            </array>
           </dict>
           <dict>
             <key>begin</key>


### PR DESCRIPTION
The issue is that the highlighting code cannot determine if a "<" character is a "less than" operator or the start of a generic type parameter section. So, currently, when "<" is seen, all code after it is highlighted as if it were in a generic type parameter section. The code that handles this only highlights "out" and "in" keywords and includes "#types".

The fix I am proposing is to remove the generic type parameter section code and add "out" and "in" to the storage.modifier.kotlin keyword list.

If proper syntax is used in a generic type parameter section, the highlighting should be correct (but non-relevant syntax will be highlighted, too). Also, "out" and "in" will be highlighted even if outside such a section. But there are other things like this that happen with the existing code, like highlighting "protected" as a keyword even if used as a variable name, which is valid syntax.

This may be the best we can do using TextMate. It certainly is better than what happens when this issue is triggered.