### PR TITLE
Removed builtin-classes include (for working with babi)

### DIFF
--- a/syntaxes/Kotlin.tmLanguage
+++ b/syntaxes/Kotlin.tmLanguage
@@ -1046,10 +1046,6 @@
           </dict>
           <dict>
             <key>include</key>
-            <string>#builtin-classes</string>
-          </dict>
-          <dict>
-            <key>include</key>
             <string>#literal-raw-string</string>
           </dict>
           <dict>


### PR DESCRIPTION
I removed the builtin-classes import because it doesn't references anything.