### PR TITLE
Kotlin consumes everything in embedded markdown

### DIFF
--- a/syntaxes/codeblock.json
+++ b/syntaxes/codeblock.json
@@ -8,8 +8,8 @@
 	],
 	"repository": {
 		"kotlin-code-block": {
-          	"begin": "(^|\\G)(\\s*)(.*)",
-          	"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+			"begin": "(^|\\G)(\\s*)(.*)",
+			"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
 			"contentName": "meta.embedded.block.kotlin",
 			"patterns": [
 				{

--- a/syntaxes/codeblock.json
+++ b/syntaxes/codeblock.json
@@ -8,8 +8,8 @@
 	],
 	"repository": {
 		"kotlin-code-block": {
-			"begin": "(^|\\G)(\\s*)(.*)",
-			"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+			"begin": "(^|\\G)kotlin",
+			"end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
 			"contentName": "meta.embedded.block.kotlin",
 			"patterns": [
 				{

--- a/syntaxes/codeblock.json
+++ b/syntaxes/codeblock.json
@@ -8,8 +8,8 @@
 	],
 	"repository": {
 		"kotlin-code-block": {
-			"begin": "kotlin",
-			"end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
+          	"begin": "(^|\\G)(\\s*)(.*)",
+          	"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
 			"contentName": "meta.embedded.block.kotlin",
 			"patterns": [
 				{


### PR DESCRIPTION
The `codeblock.json` file here is supposed to catch a code block that starts with `kotlin`, but it actually works when the word `kotlin` appears anywhere in the code block, which is... really unfortunate when writing Android docs! 

This fix makes it so that it only applies when the code block _starts_ with `kotlin`. 

To test:
- put the cursor anywhere in the `hello = 1` text
- open the command palette (ctrl+shift+P)
- choose `Developer Inspect Editor and Token Scopes`
- check the `language` field in the pop-up

This should highlight as Kotlin:
````
```kotlin
hello = 1
```
````

While this should not:
````
```groovy 
android {
  kotlinOptions {
    hello = 1
  }
}
```
````

Fixes #48